### PR TITLE
Attempt to provide correct API for multipart resources management

### DIFF
--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -38,7 +38,9 @@
     InterfaceHttpData
     InterfaceHttpData$HttpDataType]))
 
-(defn boundary []
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  boundary []
   (-> (ThreadLocalRandom/current) .nextLong Long/toHexString .toLowerCase))
 
 (defn mime-type-descriptor
@@ -48,7 +50,9 @@
    (when encoding
      (str "; charset=" encoding))))
 
-(defn populate-part
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  populate-part
   "Generates a part map of the appropriate format"
   [{:keys [part-name content mime-type charset transfer-encoding name]}]
   (let [file? (instance? File content)
@@ -80,7 +84,9 @@
 ;;
 ;; Note, that you can use transfer-encoding=nil or :binary to leave data "as is".
 ;; transfer-encoding=nil omits "Content-Transfer-Encoding" header.
-(defn part-headers [^String part-name ^String mime-type transfer-encoding name]
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  part-headers [^String part-name ^String mime-type transfer-encoding name]
   (let [cd (str "Content-Disposition: form-data; name=\"" part-name "\""
              (when name (str "; filename=\"" name "\""))
              "\r\n")
@@ -90,7 +96,9 @@
               (str "Content-Transfer-Encoding: " (cc/name transfer-encoding) "\r\n"))]
     (bs/to-byte-buffer (str cd ct cte "\r\n"))))
 
-(defn encode-part
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  encode-part
   "Generates the byte representation of a part for the bytebuffer"
   [{:keys [part-name content mime-type charset transfer-encoding name] :as part}]
   (let [headers (part-headers part-name mime-type transfer-encoding name)

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -169,17 +169,37 @@
 
     (.close ^java.io.Closeable s)))
 
+(defn- coerce-chunk-content [{:keys [content file] :as chunk}]
+  (let [content' (cond
+                   (string? content)
+                   content
+
+                   (some? file)
+                   (slurp (.getAbsolutePath ^java.io.File file))
+
+                   :else
+                   (bs/to-string content))]
+    (assoc chunk :content content')))
+
 (defn- pack-chunk [{:keys [content] :as chunk}]
-  (cond-> (dissoc chunk :file)
-    (not (string? content))
-    (dissoc :content)))
+  (-> chunk
+      (coerce-chunk-content)
+      (dissoc :file :release)))
 
 (defn- decode-handler [req]
-  (let [chunks (-> req
-                   mp/decode-request
-                   s/stream->seq)]
+  (let [req' (mp/decode-request req {:memory-limit 12})
+        chunks (s/stream->seq req')
+        body (pr-str (map pack-chunk chunks))]
+    (doseq [{:keys [release file content]} chunks]
+      ;; we should be able to read file before removal (if any)
+      (when (some? file)
+        (is (some? (slurp (.getAbsolutePath ^java.io.File file)))))
+      (release)
+      ;; temp file is now removed (if any)
+      (when (some? file)
+        (is (not (.exists ^java.io.File file)))))
     {:status 200
-     :body (pr-str (map pack-chunk chunks))}))
+     :body body}))
 
 (defn- test-decoder [port url raw-stream?]
   (let [s (http/start-server decode-handler {:port port


### PR DESCRIPTION
The problem itself was described in #431.

Here is an implementation of another approach. Each chunk of decoded request now has `:release` closure that should be called by the end user **after** chunk is used. Looks somewhat clumsy to me but at least it's fair enough in terms of handling resources allocated earlier. I tried really hard to emphasize the idea in docs and cover with tests. Not sure if it's clear enough tho'. 

Decoder automatically takes care of those chunks that we not "used" which might be a problem too. Let's say I got a request with 2 files from the client but my handler actually does `(stream/take! chunks)` to deal with 1 of them. The underlying decoder will eventually read the entire input stream and parse that to `HttpData` that will be removed from cleaning procedure right after chunk was read from the chunks stream. Potentially it's a situation of another race: either `d/chain` callback or `release` wins. But I think it's better to try to release the same resource twice instead of not trying at all. Also not sure about performance penalties here, seems like a lot of juggling with callbacks is required here (see `read-attributes` implementation) @ztellman 