### PR TITLE
Server should respond with 414 status code only in case URI is too long 

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -212,6 +212,8 @@
 (defn uri-too-long? [^Throwable cause]
   (and
    (instance? TooLongFrameException cause)
+   ;; seems like there's no other way to distinguish too long
+   ;; URI from too long header or too large HTTP entity
    (str/starts-with? (.getMessage cause) "An HTTP line is larger than")))
 
 (defn reject-invalid-request [ctx ^HttpRequest req]

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -236,6 +236,13 @@
     (with-handler basic-handler
       (is (= 414 (:status @(http-get long-url)))))))
 
+(deftest test-overly-long-header
+  (let [url (str "http://localhost:" port)
+        long-header-value (apply str (repeat 1e5 "a"))
+        opts {:headers {"X-Long" long-header-value}}]
+    (with-handler basic-handler
+      (is (= 400 (:status @(http-get url opts)))))))
+
 (deftest test-echo
   (with-handler basic-handler
     (doseq [len [1e3 1e4 1e5 1e6 1e7]]

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -232,8 +232,9 @@
         deref))))
 
 (deftest test-overly-long-request
-  (with-handler basic-handler
-    (= 414 @(http-get (apply str "http://localhost:" port  "/" (repeat 1e4 "a"))))))
+  (let [long-url (apply str "http://localhost:" port  "/" (repeat 1e4 "a"))]
+    (with-handler basic-handler
+      (is (= 414 (:status @(http-get long-url)))))))
 
 (deftest test-echo
   (with-handler basic-handler


### PR DESCRIPTION
There're few other cases when HTTP request decoder might fail, i.e. header is too long or http version is invalid. Status code `414 URI Too Long` should not be used for those. New implementation carefully chooses a status code based on the actual error. Test cases are added to cover more cases (existing test case is fixed also as it didn't test anything).