### PR TITLE
Catch FileNotFoundException when sending file body

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -558,8 +558,10 @@
                 (send-streaming-body ch msg body))
               (catch Throwable e
                 (let [class-name (.getName (class body))]
-                  (log/error e "error sending body of type " class-name))
-                (send-internal-error ch msg body)))]
+                  (log/errorf "error sending body of type %s: %s"
+                              class-name
+                              (.getMessage ^Throwable e)))
+                (send-internal-error ch msg)))]
 
       (when-not keep-alive?
         (handle-cleanup ch f))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -50,10 +50,6 @@
     [java.io
      File
      RandomAccessFile
-     Closeable
-     FileNotFoundException
-     StringWriter
-     PrintWriter
      Closeable]
     [java.nio.file Path]
     [java.nio.channels

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -94,18 +94,7 @@
         TimeUnit/MILLISECONDS)
       (.get ref))))
 
-(defn error-response [^Throwable e]
-  (log/error e "error in HTTP handler")
-  {:status 500
-   :headers {"content-type" "text/plain"}
-   :body (let [w (java.io.StringWriter.)]
-           (.printStackTrace e (java.io.PrintWriter. w))
-           (str w))})
-
-(let [[server-name connection-name date-name]
-      (map #(HttpHeaders/newEntity %) ["Server" "Connection" "Date"])
-
-      [server-value keep-alive-value close-value]
+(let [[server-value keep-alive-value close-value]
       (map #(HttpHeaders/newEntity %) ["Aleph/0.4.6" "Keep-Alive" "Close"])]
   (defn send-response
     [^ChannelHandlerContext ctx keep-alive? ssl? rsp]
@@ -114,27 +103,27 @@
             [(http/ring-response->netty-response rsp)
              (get rsp :body)]
             (catch Throwable e
-              (let [rsp (error-response e)]
+              (let [rsp (http/error-response e)]
                 [(http/ring-response->netty-response rsp)
                  (get rsp :body)])))]
 
       (netty/safe-execute ctx
         (let [headers (.headers rsp)]
 
-          (when-not (.contains headers ^CharSequence server-name)
-            (.set headers ^CharSequence server-name server-value))
+          (when-not (.contains headers ^CharSequence http/server-name)
+            (.set headers ^CharSequence http/server-name server-value))
 
-          (when-not (.contains headers ^CharSequence date-name)
-            (.set headers ^CharSequence date-name (date-header-value ctx)))
+          (when-not (.contains headers ^CharSequence http/date-name)
+            (.set headers ^CharSequence http/date-name (date-header-value ctx)))
 
-          (.set headers ^CharSequence connection-name (if keep-alive? keep-alive-value close-value))
+          (.set headers ^CharSequence http/connection-name (if keep-alive? keep-alive-value close-value))
 
           (http/send-message ctx keep-alive? ssl? rsp body))))))
 
 ;;;
 
 (defn invalid-value-response [req x]
-  (error-response
+  (http/error-response
     (IllegalArgumentException.
       (str "cannot treat "
         (pr-str x)
@@ -165,7 +154,7 @@
                     (try
                       (rejected-handler req')
                       (catch Throwable e
-                        (error-response e)))
+                        (http/error-response e)))
                     {:status 503
                      :headers {"content-type" "text/plain"}
                      :body "503 Service Unavailable"})))
@@ -174,7 +163,7 @@
               (try
                 (handler req')
                 (catch Throwable e
-                  (error-response e))))]
+                  (http/error-response e))))]
 
     (-> previous-response
       (d/chain'
@@ -183,7 +172,7 @@
           (netty/release req)
           (netty/release body)
           (-> rsp
-            (d/catch' error-response)
+            (d/catch' http/error-response)
             (d/chain'
               (fn [rsp]
                 (when (not (-> req' ^AtomicBoolean (.websocket?) .get))

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -353,6 +353,26 @@
                   :body
                   bs/to-string)))))
 
+(defn non-existing-file-handler [req]
+  {:status 200
+   :body (File. "this-file-does-not-exist.sure")})
+
+(defn- assert-file-error []
+  (is (= 500 (-> (http/get (str "http://localhost:" port)
+                           {:throw-exceptions? false})
+                 (d/timeout! 1e3)
+                 deref
+                 :status))))
+
+(deftest test-sending-non-existing-file
+  (testing "sending FileRegion"
+    (with-handler non-existing-file-handler
+      (assert-file-error)))
+
+  (testing "sending chunked body"
+    (with-compressed-handler non-existing-file-handler
+      (assert-file-error))))
+
 ;;;
 
 (defn get-netty-client-event-threads []


### PR DESCRIPTION
Fixes #459.

In general, we need to be more careful with the cleanup procedure and any time `send-message` failed for whatever **uncaught** reason close the connection. This specific just PR covers one of the obvious failures that the user might face. /cc #457.