### PR TITLE
Get rid of `:max-chunk-size` both for HTTP server and client

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -9,7 +9,8 @@
      [server :as server]
      [client :as client]
      [client-middleware :as middleware]]
-    [aleph.netty :as netty])
+    [aleph.netty :as netty]
+    [clojure.tools.logging :as log])
   (:import
     [io.aleph.dirigiste Pools]
     [aleph.utils
@@ -42,12 +43,13 @@
    | `rejected-handler` | a spillover request-handler which is invoked when the executor's queue is full, and the request cannot be processed.  Defaults to a `503` response.
    | `max-initial-line-length` | the maximum characters that can be in the initial line of the request, defaults to `8192`
    | `max-header-size` | the maximum characters that can be in a single header entry of a request, defaults to `8192`
-   | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `16384`
    | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds"
   [handler options]
+  (when (contains? options :max-chunk-size)
+    (log/warn "Ignoring :max-chunk-size option as it was deprecated"))
   (server/start-server handler options))
 
 (defn- create-connection
@@ -114,7 +116,6 @@
    | `raw-stream?` | if `true`, bodies of responses will not be buffered at all, and represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `max-initial-line-length` | the maximum length of the initial line (e.g. HTTP/1.0 200 OK), defaults to `65536`
    | `max-header-size` | the maximum characters that can be in a single header entry of a response, defaults to `65536`
-   | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed response, defaults to `65536`
    | `name-resolver` | specify the mechanism to resolve the address of the unresolved named address. When not set or equals to `:default`, JDK's built-in domain name lookup mechanism is used (blocking). Set to`:noop` not to resolve addresses or pass an instance of `io.netty.resolver.AddressResolverGroup` you need. Note, that if the appropriate connection-pool is created with dns-options shared DNS resolver would be used
    | `proxy-options` | a map to specify proxy settings. HTTP, SOCKS4 and SOCKS5 proxies are supported. Note, that when using proxy `connections-per-host` configuration is still applied to the target host disregarding tunneling settings. If you need to limit number of connections to the proxy itself use `total-connections` setting.
    | `response-executor` | optional `java.util.concurrent.Executor` that will execute response callbacks
@@ -151,6 +152,9 @@
     (throw
      (IllegalArgumentException.
       ":idle-timeout option is not allowed when :keep-alive? is explicitly disabled")))
+
+  (when (contains? connection-options :max-chunk-size)
+    (log/warn "Ignoring :max-chunk-size option as it was deprecated"))
 
   (let [conn-options' (cond-> connection-options
                         (some? dns-options)

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -394,7 +394,6 @@
      response-buffer-size
      max-initial-line-length
      max-header-size
-     max-chunk-size
      raw-stream?
      proxy-options
      ssl?
@@ -405,7 +404,6 @@
      response-buffer-size 65536
      max-initial-line-length 65536
      max-header-size 65536
-     max-chunk-size 65536
      idle-timeout 0}}]
   (fn [^ChannelPipeline pipeline]
     (let [handler (if raw-stream?
@@ -420,7 +418,7 @@
           (HttpClientCodec.
             max-initial-line-length
             max-header-size
-            max-chunk-size
+            Integer/MAX_VALUE
             false
             false))
         (.addLast "streamer" ^ChannelHandler (ChunkedWriteHandler.))

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -403,7 +403,6 @@
      request-buffer-size
      max-initial-line-length
      max-header-size
-     max-chunk-size
      raw-stream?
      ssl?
      compression?
@@ -413,7 +412,6 @@
     {request-buffer-size 16384
      max-initial-line-length 8192
      max-header-size 8192
-     max-chunk-size 16384
      compression? false
      idle-timeout 0}}]
   (fn [^ChannelPipeline pipeline]
@@ -426,7 +424,7 @@
           (HttpServerCodec.
             max-initial-line-length
             max-header-size
-            max-chunk-size
+            Integer/MAX_VALUE
             false))
         (.addLast "continue-handler" (HttpServerExpectContinueHandler.))
         (.addLast "request-handler" ^ChannelHandler handler)


### PR DESCRIPTION
A reason for doing this was mentioned [here](https://github.com/ztellman/aleph/issues/443).