### PR TITLE
HTTP client to support body decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Aleph attempts to mimic the clj-http API and capabilities fully. It supports mul
 
 * `:cache` and `:cache-config` options are not supported as for now
 
+* `:decompress-body?` configuration should be set for the connection using `:connection-options`, defaults to `false`. When sets to `true`, "Accept-Encoding" request header would be set to "gzip, deflate" if not set manually. Note, that decompression automatically removes "Content-Encoding" header, to get the value of the original header, set `:save-content-encoding?` option to `true` (the value of the header will be copied to "X-Origin-Content-Encoding")
+
 Aleph client also supports fully async and [highly customizable](https://github.com/ztellman/aleph/blob/d33c76d6c7d1bf9788369fe6fd9d0e56434c8244/src/aleph/netty.clj#L783-L796) DNS resolver.
 
 To learn more, [read the example code](http://aleph.io/examples/literate.html#aleph.examples.http).

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -120,6 +120,7 @@
    | `response-executor` | optional `java.util.concurrent.Executor` that will execute response callbacks
    | `log-activity` | when set, logs all events on each channel (connection) with a log level given. Accepts either one of `:trace`, `:debug`, `:info`, `:warn`, `:error` or an instance of `io.netty.handler.logging.LogLevel`. Note, that this setting *does not* enforce any changes to the logging configuration (default configuration is `INFO`, so you won't see any `DEBUG` or `TRACE` level messages, unless configured explicitly)
    | `decompress-body?` | when set to `true`, automatically decompresses the resulting gzip or deflate stream if the `Content-Encoding` header is found on the response, defaults to `false`
+   | `save-content-encoding?` | set to `true` to get information about Content-Encoding of the response before decompression, defaults to `false`
 
    Supported `proxy-options` are
 
@@ -152,6 +153,12 @@
     (throw
      (IllegalArgumentException.
       ":idle-timeout option is not allowed when :keep-alive? is explicitly disabled")))
+
+  (when (and (not (:decompress-body? connection-options))
+             (true? (:save-content-encoding? connection-options false)))
+    (throw
+     (IllegalArgumentException.
+      "Using :save-content-encoding? option with disabled auto decompression is disabled")))
 
   (let [conn-options' (cond-> connection-options
                         (some? dns-options)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -119,6 +119,7 @@
    | `proxy-options` | a map to specify proxy settings. HTTP, SOCKS4 and SOCKS5 proxies are supported. Note, that when using proxy `connections-per-host` configuration is still applied to the target host disregarding tunneling settings. If you need to limit number of connections to the proxy itself use `total-connections` setting.
    | `response-executor` | optional `java.util.concurrent.Executor` that will execute response callbacks
    | `log-activity` | when set, logs all events on each channel (connection) with a log level given. Accepts either one of `:trace`, `:debug`, `:info`, `:warn`, `:error` or an instance of `io.netty.handler.logging.LogLevel`. Note, that this setting *does not* enforce any changes to the logging configuration (default configuration is `INFO`, so you won't see any `DEBUG` or `TRACE` level messages, unless configured explicitly)
+   | `decompress-body?` | when set to `true`, automatically decompresses the resulting gzip or deflate stream if the `Content-Encoding` header is found on the response, defaults to `false`
 
    Supported `proxy-options` are
 

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -515,7 +515,7 @@
                         (not (.get (.headers req') "Proxy-Connection")))
                   (.set (.headers req') "Proxy-Connection" "Keep-Alive"))
                 (when (and decompress-body?
-                           (nil? (.get (.headers req') "Accept-Encoding")))
+                           (not (.get (.headers req') "Accept-Encoding")))
                   (.set (.headers req') "Accept-Encoding" "gzip, deflate"))
 
                 (let [body (:body req)

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -404,22 +404,6 @@
       (copy-encoding-header! msg))
     (.fireChannelRead ctx msg))))
 
-(defn coerce-log-level [level]
-  (if (instance? LogLevel level)
-    level
-    (let [netty-level (case level
-                        :trace LogLevel/TRACE
-                        :debug LogLevel/DEBUG
-                        :info LogLevel/INFO
-                        :warn LogLevel/WARN
-                        :error LogLevel/ERROR
-                        nil)]
-      (when (nil? netty-level)
-        (throw (IllegalArgumentException.
-                (str "unknown log level given: " level))))
-      netty-level)))
-
-
 (defn pipeline-builder
   [response-stream
    {:keys

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -858,7 +858,7 @@
                       heartbeats)]
     (d/chain'
       (netty/create-client
-       (fn [^ChannelPipeline pipeline]
+        (fn [^ChannelPipeline pipeline]
           (doto pipeline
             (.addLast "http-client" (HttpClientCodec.))
             (.addLast "aggregator" (HttpObjectAggregator. 16384))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -374,7 +374,7 @@
 
 (defn copy-encoding-header! [^HttpResponse msg]
   (let [headers (.headers msg)]
-    (when-let [encoding (.get headers "content-encoding")]
+    (when-let [encoding (.get headers http/content-encoding-name)]
       (.set headers http/origin-content-encoding-name encoding))))
 
 (defn copy-original-encoding-handler []

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -61,7 +61,8 @@
       (map str/lower-case ks)
       (map #(HttpHeaders/newEntity %) ks))))
 
-(def origin-content-encoding-name "x-origin-content-encoding")
+(def ^CharSequence origin-content-encoding-name (HttpHeaders/newEntity "x-origin-content-encoding"))
+(def ^CharSequence content-encoding-name (HttpHeaders/newEntity "content-encoding"))
 
 (def ^ConcurrentHashMap cached-header-keys (ConcurrentHashMap.))
 

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -61,6 +61,8 @@
       (map str/lower-case ks)
       (map #(HttpHeaders/newEntity %) ks))))
 
+(def origin-content-encoding-name "x-origin-content-encoding")
+
 (def ^ConcurrentHashMap cached-header-keys (ConcurrentHashMap.))
 
 (defn normalize-header-key


### PR DESCRIPTION
Covers #444, differences from `clj-http` API:

1. `:decompress-body?` is set for the **connection**, not for the **request**

2. `:decompress-body?` defaults to `false` when `clj-http` sets it to `true`. I will probably prefer the latest, but it would be a breaking change

3. `HttpContentDecompressor` removes "Content-Encoding" header when done. A simple way to get the information of the origin content encoding (`:orig-content-encoding` with `clj-http`) is to introduce another pipeline handler that copies the value to another header "X-Origin-Content-Encoding". I don't see any use cases except debug (well, it's used in tests too). So I introduced another option to switch this ON and not waste resources when the user doesn't need it: `:save-content-encoding?`.

4. It also automatically includes "Accept-Encoding" header as "gzip, deflate" if not set by the user manually.