### PR TITLE
KQueue support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,6 @@
 
 (def netty-modules
   '[transport
-    transport-native-epoll
-    transport-native-kqueue
     codec
     codec-http
     handler
@@ -15,7 +13,11 @@
   '[[org.clojure/tools.logging "0.4.1" :exclusions [org.clojure/clojure]]
     [manifold "0.1.9-alpha3"]
     [byte-streams "0.2.5-alpha2"]
-    [potemkin "0.4.5"]])
+    [potemkin "0.4.5"]
+    [io.netty/netty-transport-native-epoll netty-version
+     :classifier "linux-x86_64"]
+    [io.netty/netty-transport-native-kqueue netty-version
+     :classifier "osx-x86_64"]])
 
 (defproject aleph "0.4.7-alpha4"
   :description "a framework for asynchronous communication"

--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,8 @@
 
 (def netty-modules
   '[transport
+    [transport-native-epoll "linux-x86_64"]
+    [transport-native-kqueue "osx-x86_64"]
     codec
     codec-http
     handler
@@ -9,15 +11,18 @@
     resolver
     resolver-dns])
 
+(defn netty-module [version name]
+  (let [[name classifier] (if (vector? name) name [name nil])
+        s (symbol "io.netty" (str "netty-" name))]
+    (if (nil? classifier)
+      (vector s version)
+      (vector s version :classifier classifier))))
+
 (def other-dependencies
   '[[org.clojure/tools.logging "0.4.1" :exclusions [org.clojure/clojure]]
     [manifold "0.1.9-alpha3"]
     [byte-streams "0.2.5-alpha2"]
-    [potemkin "0.4.5"]
-    [io.netty/netty-transport-native-epoll netty-version
-     :classifier "linux-x86_64"]
-    [io.netty/netty-transport-native-kqueue netty-version
-     :classifier "osx-x86_64"]])
+    [potemkin "0.4.5"]])
 
 (defproject aleph "0.4.7-alpha4"
   :description "a framework for asynchronous communication"
@@ -26,9 +31,7 @@
   :license {:name "MIT License"}
   :dependencies ~(concat
                    other-dependencies
-                   (map
-                     #(vector (symbol "io.netty" (str "netty-" %)) netty-version)
-                     netty-modules))
+                   (map (partial netty-module netty-version) netty-modules))
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
                                   [criterium "0.4.4"]
                                   [cheshire "5.8.1"]

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
 (def netty-modules
   '[transport
     transport-native-epoll
+    transport-native-kqueue
     codec
     codec-http
     handler

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -269,6 +269,23 @@
     (executor/with-executor response-executor
       ((middleware
          (fn [req]
+           ;; xxx: if I'm working with unix-socket here,
+           ;; I probably want to reshape the request slightly
+           ;; to prevent troubles caused by java.net.URL parser
+           ;; let's say I want to run something like
+           ;;
+           ;; (http/get "/images/json" {:unix-socket "/var/run/docker.sock"})
+           ;;
+           ;; "/images/json" is not a valid URL, no protocol, no host
+           ;; Which is a bad thing when I need to setup a connection to
+           ;; a remote address, but it's perfectly valid for unix socket
+           ;; What I can do here: take URL requested, try to parse it
+           ;; and if it fails just to put some dummy values to a host & port
+           ;; SSL will not work, but if don't pass any server name I should
+           ;; not expect it work at the first place. The only thing...
+           ;; I don't know the connection pool configuration here, meaning
+           ;; I have no idea if it's allowed to pass URI with no additional
+           ;; information
            (let [k (client/req->domain req)
                  start (System/currentTimeMillis)]
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -108,7 +108,7 @@
    |:---|:---
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object, only required if a custom context is required
    | `local-address` | an optional `java.net.SocketAddress` describing which local interface should be used
-   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to
+   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.Bootstrap` object and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `insecure?` | if `true`, ignores the certificate for any `https://` domains

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -21,8 +21,7 @@
      URI
      InetSocketAddress]
     [java.util.concurrent
-     TimeoutException]
-    [io.netty.channel.unix DomainSocketAddress]))
+     TimeoutException]))
 
 (defn start-server
   "Starts an HTTP server using the provided Ring `handler`.  Returns a server object which can be stopped
@@ -55,24 +54,15 @@
   "Returns a deferred that yields a function which, given an HTTP request, returns
    a deferred representing the HTTP response.  If the server disconnects, all responses
    will be errors, and a new connection must be created."
-  [^URI uri {:keys [unix-socket] :as options} middleware on-closed]
+  [^URI uri options middleware on-closed]
   (let [scheme (.getScheme uri)
         ssl? (= "https" scheme)
-        remote-address (cond
-                         (and (some? unix-socket)
-                              (instance? DomainSocketAddress unix-socket))
-                         unix-socket
-
-                         (some? unix-socket)
-                         (DomainSocketAddress. ^String unix-socket)
-
-                         :else
-                         (InetSocketAddress/createUnresolved
-                          (.getHost uri)
-                          (int
-                           (or
-                            (when (pos? (.getPort uri)) (.getPort uri))
-                            (if ssl? 443 80)))))]
+        remote-address (InetSocketAddress/createUnresolved
+                        (.getHost uri)
+                        (int
+                         (or
+                          (when (pos? (.getPort uri)) (.getPort uri))
+                          (if ssl? 443 80))))]
     (-> (client/http-connection
           remote-address
           ssl?

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -33,6 +33,7 @@
    |:---------|:-------------
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` |  a `java.net.SocketAddress` specifying both the port and interface to bind to.
+   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object if an SSL connection is desired |
    | `manual-ssl?` | set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform`) to select the SSL context based on the client's indicated host name. |

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -33,7 +33,7 @@
    |:---------|:-------------
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` |  a `java.net.SocketAddress` specifying both the port and interface to bind to.
-   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
+   | `unix-socket` | an optional path to unix domain socket endpoint, instance of `java.io.File` or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object if an SSL connection is desired |
    | `manual-ssl?` | set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform`) to select the SSL context based on the client's indicated host name. |
@@ -109,7 +109,7 @@
    |:---|:---
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object, only required if a custom context is required
    | `local-address` | an optional `java.net.SocketAddress` describing which local interface should be used
-   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
+   | `unix-socket` | an optional path to unix domain socket endpoint, instance of `java.io.File` or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.Bootstrap` object and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `insecure?` | if `true`, ignores the certificate for any `https://` domains

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -164,7 +164,23 @@
      (IllegalArgumentException.
       ":idle-timeout option is not allowed when :keep-alive? is explicitly disabled")))
 
+  (when (and (some? (:unix-socket connection-options))
+             (or (some? dns-options)
+                 (some? (:name-resolver connection-options))))
+    (throw
+     (IllegalArgumentException.
+      "unix socket connection does not support custom name resolvers")))
+
+  (when (and (some? (:unix-socket connection-options))
+             (some? (:proxy-options connection-options)))
+    (throw
+     (IllegalArgumentException.
+      "unix socket connection does not support proxies")))
+
   (let [conn-options' (cond-> connection-options
+                        (some? (:unix-socket connection-options))
+                        (assoc :name-resolver :noop)
+
                         (some? dns-options)
                         (assoc :name-resolver (netty/dns-resolver-group dns-options)))
         p (promise)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -45,7 +45,8 @@
    | `max-initial-line-length` | the maximum characters that can be in the initial line of the request, defaults to `8192`
    | `max-header-size` | the maximum characters that can be in a single header entry of a request, defaults to `8192`
    | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `16384`
-   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
+   | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`
+   | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds"
@@ -114,7 +115,8 @@
    | `response-buffer-size` | the amount of the response, in bytes, that is buffered before the request returns, defaults to `65536`.  This does *not* represent the maximum size response that the client can handle (which is unbounded), and is only a means of maximizing performance.
    | `keep-alive?` | if `true`, attempts to reuse connections for multiple requests, defaults to `true`.
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds.
-   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
+   | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`
+   | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`
    | `raw-stream?` | if `true`, bodies of responses will not be buffered at all, and represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `max-initial-line-length` | the maximum length of the initial line (e.g. HTTP/1.0 200 OK), defaults to `65536`
    | `max-header-size` | the maximum characters that can be in a single header entry of a response, defaults to `65536`
@@ -222,7 +224,8 @@
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to `65536`.
    | `max-frame-size` | maximum aggregate message size, in bytes, defaults to `1048576`.
    | `bootstrap-transform` | an optional function that takes an `io.netty.bootstrap.Bootstrap` object and modifies it.
-   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
+   | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`
+   | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`
    | `heartbeats` | optional configuration to send Ping frames to the server periodically (if the connection is idle), configuration keys are `:send-after-idle` (in milliseconds), `:payload` (optional, empty frame by default) and `:timeout` (optional, to close the connection if Pong is not received after specified timeout)."
   ([url]
     (websocket-client url nil))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -471,11 +471,13 @@
            on-closed
            response-executor
            epoll?
+           kqueue?
            proxy-options]
     :or {bootstrap-transform identity
          keep-alive? true
          response-buffer-size 65536
          epoll? false
+         kqueue? false
          name-resolver :default}
     :as options}]
   (let [responses (s/stream 1024 nil response-executor)
@@ -499,7 +501,8 @@
             local-address
             epoll?
             name-resolver
-            unix-socket')]
+            unix-socket'
+            kqueue?)]
     (d/chain' c
       (fn [^Channel ch]
 
@@ -765,6 +768,7 @@
            bootstrap-transform
            pipeline-transform
            epoll?
+           kqueue?
            sub-protocols
            extensions?
            max-frame-payload
@@ -825,6 +829,9 @@
               (if ssl? 443 80)
               (.getPort uri))))
         local-address
-        epoll?)
+        epoll?
+        nil
+        nil
+        kqueue?)
       (fn [_]
         s))))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -481,8 +481,7 @@
                          (DomainSocketAddress. ^String unix-socket)))
         host (.getHostName remote-address)
         port (.getPort remote-address)
-        explicit-port? (when inet-socket?
-                         (and (pos? port) (not= port (if ssl? 443 80))))
+        explicit-port? (and (pos? port) (not= port (if ssl? 443 80)))
         c (netty/create-client
             (pipeline-builder responses (assoc options :ssl? ssl?))
             (when ssl?
@@ -509,13 +508,14 @@
                                         (if (non-tunnel-proxy? proxy-options')
                                           (assoc req :uri (:request-url req))
                                           req))]
-                (when-not (and (.get (.headers req') "Host")
-                               (some? host))
+                (when-not (.get (.headers req') "Host")
                   (.set (.headers req')
                         HttpHeaderNames/HOST
                         (str host (when explicit-port? (str ":" port)))))
+
                 (when-not (.get (.headers req') "Connection")
                   (HttpUtil/setKeepAlive req' keep-alive?))
+
                 (when (and (non-tunnel-proxy? proxy-options')
                         (get proxy-options :keep-alive? true)
                         (not (.get (.headers req') "Proxy-Connection")))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -779,6 +779,7 @@
          pipeline-transform identity
          raw-stream? false
          epoll? false
+         kqueue? false
          sub-protocols nil
          extensions? false
          max-frame-payload 65536

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -473,12 +473,12 @@
     :as options}]
   (let [responses (s/stream 1024 nil response-executor)
         requests (s/stream 1024 nil nil)
-        unix-socket? (instance? DomainSocketAddress remote-address)
-        host (when-not unix-socket?
-               (.getHostName remote-address))
-        port (when-not unix-socket?
-               (.getPort remote-address))
-        explicit-port? (when-not unix-socket?
+        inet-socket? (instance? InetSocketAddress remote-address)
+        host (when inet-socket?
+               (.getHostName ^InetSocketAddress remote-address))
+        port (when inet-socket?
+               (.getPort ^InetSocketAddress remote-address))
+        explicit-port? (when inet-socket?
                          (and (pos? port) (not= port (if ssl? 443 80))))
         c (netty/create-client
             (pipeline-builder responses (assoc options :ssl? ssl?))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -483,9 +483,7 @@
   (let [responses (s/stream 1024 nil response-executor)
         requests (s/stream 1024 nil nil)
         unix-socket' (when (some? unix-socket)
-                       (if (instance? DomainSocketAddress unix-socket)
-                         unix-socket
-                         (DomainSocketAddress. ^String unix-socket)))
+                       (netty/coerce-unix-socket unix-socket))
         host (.getHostName remote-address)
         port (.getPort remote-address)
         explicit-port? (and (pos? port) (not= port (if ssl? 443 80)))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -12,7 +12,6 @@
      IOException]
     [java.net
      URI
-     SocketAddress
      InetSocketAddress
      IDN
      URL]
@@ -36,7 +35,6 @@
      Channel
      ChannelHandler ChannelHandlerContext
      ChannelPipeline]
-    [io.netty.channel.unix DomainSocketAddress]
     [io.netty.handler.codec
      TooLongFrameException]
     [io.netty.handler.timeout
@@ -70,7 +68,6 @@
     [io.netty.handler.logging
      LoggingHandler
      LogLevel]
-    [io.netty.channel.unix DomainSocketAddress]
     [java.util.concurrent
      ConcurrentLinkedQueue]
     [java.util.concurrent.atomic
@@ -488,7 +485,6 @@
   [^InetSocketAddress remote-address
    ssl?
    {:keys [local-address
-           unix-socket
            raw-stream?
            bootstrap-transform
            name-resolver
@@ -511,8 +507,6 @@
     :as options}]
   (let [responses (s/stream 1024 nil response-executor)
         requests (s/stream 1024 nil nil)
-        unix-socket' (when (some? unix-socket)
-                       (netty/coerce-unix-socket unix-socket))
         host (.getHostName remote-address)
         port (.getPort remote-address)
         explicit-port? (and (pos? port) (not= port (if ssl? 443 80)))
@@ -529,8 +523,7 @@
             :local-address local-address
             :epoll? epoll?
             :kqueue? kqueue?
-            :name-resolver name-resolver
-            :unix-socket unix-socket'})]
+            :name-resolver name-resolver})]
     (d/chain' c
       (fn [^Channel ch]
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -485,7 +485,7 @@
       bootstrap-transform
       (when (and shutdown-executor? (instance? ExecutorService executor))
         #(.shutdown ^ExecutorService executor))
-      ;; xxx: we should handler misconfiguration here
+      ;; xxx: we should handle misconfiguration here
       (cond
         (some? socket-address)
         socket-address

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -484,7 +484,9 @@
       (pipeline-builder
         handler
         pipeline-transform
-        (assoc options :executor executor :ssl? (or manual-ssl? (boolean ssl-context))))
+        (assoc options
+               :executor executor
+               :ssl? (or manual-ssl? (boolean ssl-context))))
       ssl-context
       bootstrap-transform
       (when (and shutdown-executor? (instance? ExecutorService executor))

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -28,6 +28,7 @@
      ChannelHandlerContext
      ChannelHandler
      ChannelPipeline]
+    [io.netty.channel.unix DomainSocketAddress]
     [io.netty.handler.stream ChunkedWriteHandler]
     [io.netty.handler.codec.http
      DefaultFullHttpResponse
@@ -443,6 +444,7 @@
   [handler
    {:keys [port
            socket-address
+           unix-socket
            executor
            bootstrap-transform
            pipeline-transform
@@ -483,7 +485,16 @@
       bootstrap-transform
       (when (and shutdown-executor? (instance? ExecutorService executor))
         #(.shutdown ^ExecutorService executor))
-      (if socket-address socket-address (InetSocketAddress. port))
+      ;; xxx: we should handler misconfiguration here
+      (cond
+        (some? socket-address)
+        socket-address
+
+        (some? unix-socket)
+        (DomainSocketAddress. ^String unix-socket)
+
+        (some? port)
+        (InetSocketAddress. port))
       epoll?)))
 
 ;;;

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -455,6 +455,7 @@
            manual-ssl?
            shutdown-executor?
            epoll?
+           kqueue?
            compression?]
     :or {bootstrap-transform identity
          pipeline-transform identity
@@ -498,7 +499,8 @@
 
         (some? port)
         (InetSocketAddress. port))
-      epoll?)))
+      epoll?
+      kqueue?)))
 
 ;;;
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -30,7 +30,6 @@
      ChannelHandlerContext
      ChannelHandler
      ChannelPipeline]
-    [io.netty.channel.unix DomainSocketAddress]
     [io.netty.channel.embedded EmbeddedChannel]
     [io.netty.handler.stream ChunkedWriteHandler]
     [io.netty.handler.timeout
@@ -510,7 +509,6 @@
   [handler
    {:keys [port
            socket-address
-           unix-socket
            executor
            bootstrap-transform
            pipeline-transform
@@ -584,9 +582,7 @@
              (.shutdown ^ExecutorService executor))
            (when (instance? ExecutorService continue-executor)
              (.shutdown ^ExecutorService continue-executor))))
-      (netty/coerce-socket-address {:socket-address socket-address
-                                    :unix-socket unix-socket
-                                    :port port})
+      (netty/coerce-socket-address {:socket-address socket-address :port port})
       epoll?
       kqueue?
       logger)))

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -489,16 +489,9 @@
       bootstrap-transform
       (when (and shutdown-executor? (instance? ExecutorService executor))
         #(.shutdown ^ExecutorService executor))
-      ;; xxx: we should handle misconfiguration here
-      (cond
-        (some? socket-address)
-        socket-address
-
-        (some? unix-socket)
-        (DomainSocketAddress. ^String unix-socket)
-
-        (some? port)
-        (InetSocketAddress. port))
+      (netty/coerce-socket-address {:socket-address socket-address
+                                    :unix-socket unix-socket
+                                    :port port})
       epoll?
       kqueue?)))
 

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1015,10 +1015,18 @@
 
          [^Class channel ^EventLoopGroup group]
          (cond
-           ;; xxx: should try KQueue too
-           unix-socket?
+           (and unix-socket? (epoll-available?))
            [EpollServerDomainSocketChannel
             (EpollEventLoopGroup. num-threads thread-factory)]
+
+           (and unix-socket? (kqueue-available?))
+           [KQueueServerDomainSocketChannel
+            (KQueueEventLoopGroup. num-threads thread-factory)]
+
+           unix-socket?
+           (throw
+            (IllegalArgumentException.
+             "unix socket supports only native transports: epoll or KQueue"))
 
            (and epoll? (epoll-available?))
            [EpollServerSocketChannel

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -927,7 +927,7 @@
            (and unix-socket? (epoll-available?))
            [EpollDomainSocketChannel @epoll-client-group]
 
-           (and unix-socket? (kqueue?-available?))
+           (and unix-socket? (kqueue-available?))
            [KQueueDomainSocketChannel @kqueue-client-group]
 
            unix-socket?
@@ -936,10 +936,10 @@
              "unix socket supports only native transports: epoll or KQueue"))
 
            (and epoll? (epoll-available?))
-           [EpollSocketChannel @epoll-client-groupl]
+           [EpollSocketChannel @epoll-client-group]
 
-           (and kqueue? (kqueue?-available?))
-           [KQueueSocketChannel @kqueue-client-groupl]
+           (and kqueue? (kqueue-available?))
+           [KQueueSocketChannel @kqueue-client-group]
 
            :else
            [NioSocketChannel @nio-client-group])

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -986,6 +986,27 @@
           (fn [_]
             (.channel ^ChannelFuture f)))))))
 
+(defn ^SocketAddress coerce-socket-address [{:keys [socket-address
+                                                    unix-socket
+                                                    port]}]
+  (cond
+    (some? socket-address)
+    socket-address
+
+    (instance? DomainSocketAddress unix-socket)
+    unix-socket
+
+    (string? unix-socket)
+    (DomainSocketAddress. ^String unix-socket)
+
+    (some? port)
+    (InetSocketAddress. port)
+
+    :else
+    (throw
+     (IllegalArgumentException.
+      "either port, socket-address or unix-address should be specified"))))
+
 (defn start-server
   ([pipeline-builder
     ^SslContext ssl-context

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -737,6 +737,9 @@
 (defn kqueue-available? []
   (KQueue/isAvailable))
 
+(defn native-transport-available? []
+  (or (epoll-available?) (kqueue-available?)))
+
 (defn get-default-event-loop-threads
   "Determines the default number of threads to use for a Netty EventLoopGroup.
    This mimics the default used by Netty as of version 4.1."

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -925,7 +925,7 @@
     unix-socket
     kqueue?]
    (when (and (some? ssl-context)
-              (not (intstance? InetSocketAddress remote-address)))
+              (not (instance? InetSocketAddress remote-address)))
      (throw
       (IllegalArgumentException.
        "to setup SSL, host and port should be provided")))
@@ -999,7 +999,8 @@
 (defn ^SocketAddress coerce-socket-address [{:keys [socket-address
                                                     unix-socket
                                                     host
-                                                    port]}]
+                                                    port]
+                                             :as options}]
   (cond
     (some? socket-address)
     socket-address
@@ -1022,7 +1023,9 @@
     :else
     (throw
      (IllegalArgumentException.
-      "either host, port, socket-address or unix-address should be specified"))))
+      (str "either "
+           (if (contains? options :host) "host, " "")
+           "port, socket-address or unix-socket should be specified")))))
 
 (defn start-server
   ([pipeline-builder

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1204,7 +1204,7 @@
            
            Object
            (toString [_]
-             (format "AlephServer[channel:%s, transport:%s]" ch transport))
+             (format "AlephServer[channel:%s, transport:%s]" ch channel))
            
            AlephServer
            (port [_]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -966,9 +966,10 @@
 
          resolver' (when (some? name-resolver)
                      (cond
-                       (= :default name-resolver) nil
+                       (identical? :default name-resolver)
+                       nil
 
-                       (= :noop name-resolver)
+                       (identical? :noop name-resolver)
                        NoopAddressResolverGroup/INSTANCE
 
                        (instance? AddressResolverGroup name-resolver)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1073,12 +1073,18 @@
      (try
        (let [b (doto (ServerBootstrap.)
                  (.option ChannelOption/SO_BACKLOG (int 1024))
-                 (.option ChannelOption/SO_REUSEADDR true)
+                 (#(when-not unix-socket?
+                     (.option ^ServerBootstrap %
+                              ChannelOption/SO_REUSEADDR
+                              true)))
                  (.option ChannelOption/MAX_MESSAGES_PER_READ Integer/MAX_VALUE)
                  (.group group)
                  (.channel channel)
                  (.childHandler (pipeline-initializer pipeline-builder))
-                 (.childOption ChannelOption/SO_REUSEADDR true)
+                 (#(when-not unix-socket?
+                     (.childOption ^ServerBootstrap %
+                                   ChannelOption/SO_REUSEADDR
+                                   true)))
                  (.childOption ChannelOption/MAX_MESSAGES_PER_READ Integer/MAX_VALUE)
                  bootstrap-transform)
 

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -918,7 +918,8 @@
                            (instance? AddressResolverGroup name-resolver)
                            name-resolver))
              b (doto (Bootstrap.)
-                 (.option ChannelOption/SO_REUSEADDR true)
+                 (#(when-not unix-socket?
+                     (.option ^Bootstrap % ChannelOption/SO_REUSEADDR true)))
                  (.option ChannelOption/MAX_MESSAGES_PER_READ Integer/MAX_VALUE)
                  (.group client-group)
                  (.channel channel)

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -15,7 +15,9 @@
      ChannelHandler
      ChannelPipeline]
     [io.netty.handler.ssl
-     SslHandler]))
+     SslHandler]
+    [io.netty.channel.unix
+     DomainSocketAddress]))
 
 (p/def-derived-map TcpConnection [^Channel ch]
   :server-name (netty/channel-server-name ch)
@@ -192,7 +194,10 @@
         local-address
         epoll?
         nil
-        unix-socket
+        (when (some? unix-socket)
+          (if (instance? DomainSocketAddress unix-socket)
+            unix-socket
+            (DomainSocketAddress. ^String unix-socket)))
         kqueue?)
       (d/catch' #(d/error! s %)))
     s))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -16,8 +16,6 @@
      ChannelPipeline]
     [io.netty.handler.ssl
      SslHandler]
-    [io.netty.channel.unix
-     DomainSocketAddress]
     [io.netty.handler.logging LoggingHandler]))
 
 (p/def-derived-map TcpConnection [^Channel ch]
@@ -70,7 +68,6 @@
    |:---|:-----
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
-   | `unix-socket` | an optional path to unix domain socket endpoint, instance of `java.io.File` or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
    | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
    | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`.
@@ -80,7 +77,6 @@
   [handler
    {:keys [port
            socket-address
-           unix-socket
            ssl-context
            bootstrap-transform
            pipeline-transform
@@ -100,7 +96,6 @@
     bootstrap-transform
     nil
     (netty/coerce-socket-address {:socket-address socket-address
-                                  :unix-socket unix-socket
                                   :port port})
     epoll?
     kqueue?
@@ -164,7 +159,6 @@
    | `port` | the port of the server.
    | `remote-address` | a `java.net.SocketAddress` specifying the server's address.
    | `local-address` | a `java.net.SocketAddress` specifying the local network interface to use.
-   | `unix-socket` | an optional path to unix domain socket endpoint, instance of `java.io.File` or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
    | `ssl-context` | an explicit `io.netty.handler.ssl.SslHandler` to use. Defers to `ssl?` and `insecure?` configuration if omitted.
    | `ssl?` | if true, the client attempts to establish a secure connection with the server.
    | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
@@ -177,7 +171,6 @@
            port
            remote-address
            local-address
-           unix-socket
            ssl-context
            ssl?
            insecure?
@@ -207,15 +200,10 @@
           :bootstrap-transform bootstrap-transform
           :remote-address (netty/coerce-socket-address
                            {:scoket-address remote-address
-                            :unix-socket unix-socket
                             :host host
                             :port port})
           :local-address local-address
           :epoll? epoll?
-          :kqueue? kqueue?
-          ;; hack so we can define both host/port and unix domain socket
-          ;; to setup SSL handler properly
-          :unix-socket (when (some? unix-socket)
-                         (netty/coerce-unix-socket unix-socket))})
+          :kqueue? kqueue?})
         (d/catch' #(d/error! s %)))
     s))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -69,7 +69,7 @@
    |:---|:-----
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
-   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
+   | `unix-socket` | an optional path to unix domain socket endpoint, instance of `java.io.File` or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
    | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
    | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`.
@@ -153,7 +153,7 @@
    | `port` | the port of the server.
    | `remote-address` | a `java.net.SocketAddress` specifying the server's address.
    | `local-address` | a `java.net.SocketAddress` specifying the local network interface to use.
-   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
+   | `unix-socket` | an optional path to unix domain socket endpoint, instance of `java.io.File` or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
    | `ssl-context` | an explicit `io.netty.handler.ssl.SslHandler` to use. Defers to `ssl?` and `insecure?` configuration if omitted.
    | `ssl?` | if true, the client attempts to establish a secure connection with the server.
    | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
@@ -202,9 +202,7 @@
         ;; hack so we can define both host/port and unix domain socket
         ;; to setup SSL handler properly
         (when (some? unix-socket)
-          (if (instance? DomainSocketAddress unix-socket)
-            unix-socket
-            (DomainSocketAddress. ^String unix-socket)))
+          (netty/coerce-unix-socket unix-socket))
         kqueue?)
       (d/catch' #(d/error! s %)))
     s))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -91,17 +91,17 @@
          kqueue? false}
     :as options}]
   (netty/start-server
-    (fn [^ChannelPipeline pipeline]
-      (.addLast pipeline "handler" (server-channel-handler handler options))
-      (pipeline-transform pipeline))
-    ssl-context
-    bootstrap-transform
-    nil
-    (netty/coerce-socket-address {:socket-address socket-address
-                                  :unix-socket unix-socket
-                                  :port port})
-    epoll?
-    kqueue?))
+   (fn [^ChannelPipeline pipeline]
+     (.addLast pipeline "handler" (server-channel-handler handler options))
+     (pipeline-transform pipeline))
+   ssl-context
+   bootstrap-transform
+   nil
+   (netty/coerce-socket-address {:socket-address socket-address
+                                 :unix-socket unix-socket
+                                 :port port})
+   epoll?
+   kqueue?))
 
 (defn- ^ChannelHandler client-channel-handler
   [{:keys [raw-stream?]}]

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -69,6 +69,7 @@
    |:---|:-----
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
+   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to bind to.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
    | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
    | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`.
@@ -78,6 +79,7 @@
   [handler
    {:keys [port
            socket-address
+           unix-socket
            ssl-context
            bootstrap-transform
            pipeline-transform
@@ -95,9 +97,9 @@
     ssl-context
     bootstrap-transform
     nil
-    (if socket-address
-      socket-address
-      (InetSocketAddress. port))
+    (netty/coerce-socket-address {:socket-address socket-address
+                                  :unix-socket unix-socket
+                                  :port port})
     epoll?
     kqueue?))
 

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -68,14 +68,23 @@
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
+   | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
+   | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?` | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users."
   [handler
-   {:keys [port socket-address ssl-context bootstrap-transform pipeline-transform epoll?]
+   {:keys [port
+           socket-address
+           ssl-context
+           bootstrap-transform
+           pipeline-transform
+           epoll?
+           kqueue?]
     :or {bootstrap-transform identity
          pipeline-transform identity
-         epoll? false}
+         epoll? false
+         kqueue? false}
     :as options}]
   (netty/start-server
     (fn [^ChannelPipeline pipeline]
@@ -87,7 +96,8 @@
     (if socket-address
       socket-address
       (InetSocketAddress. port))
-    epoll?))
+    epoll?
+    kqueue?))
 
 (defn- ^ChannelHandler client-channel-handler
   [{:keys [raw-stream?]}]
@@ -113,7 +123,7 @@
            (d/success! d
              (doto
                (s/splice
-                 (netty/sink ch true netty/to-byte-buf)
+                (netty/sink ch true netty/to-byte-buf)
                  (reset! in (netty/source ch)))
                (reset-meta! {:aleph/channel ch}))))
          (.fireChannelActive ctx))
@@ -141,13 +151,26 @@
    | `local-address` | a `java.net.SocketAddress` specifying the local network interface to use.
    | `ssl-context` | an explicit `io.netty.handler.ssl.SslHandler` to use. Defers to `ssl?` and `insecure?` configuration if omitted.
    | `ssl?` | if true, the client attempts to establish a secure connection with the server.
+   | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
+   | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`.
    | `insecure?` | if true, the client will ignore the server's certificate.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.Bootstrap` object, which represents the client, and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?` | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users."
-  [{:keys [host port remote-address local-address ssl-context ssl? insecure? pipeline-transform bootstrap-transform epoll?]
+  [{:keys [host
+           port
+           remote-address
+           local-address
+           ssl-context
+           ssl?
+           insecure?
+           pipeline-transform
+           bootstrap-transform
+           epoll?
+           kqueue?]
     :or {bootstrap-transform identity
-         epoll? false}
+         epoll? false
+         kqueue? false}
     :as options}]
   (let [[s handler] (client-channel-handler options)]
     (->
@@ -165,6 +188,9 @@
         bootstrap-transform
         (or remote-address (InetSocketAddress. ^String host (int port)))
         local-address
-        epoll?)
+        epoll?
+        nil
+        nil
+        kqueue?)
       (d/catch' #(d/error! s %)))
     s))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -149,6 +149,7 @@
    | `port` | the port of the server.
    | `remote-address` | a `java.net.SocketAddress` specifying the server's address.
    | `local-address` | a `java.net.SocketAddress` specifying the local network interface to use.
+   | `unix-socket` | an optional path to unix domain socket endpoint or intance of `io.netty.channel.unix.DomainSocketAddress` to connect to.
    | `ssl-context` | an explicit `io.netty.handler.ssl.SslHandler` to use. Defers to `ssl?` and `insecure?` configuration if omitted.
    | `ssl?` | if true, the client attempts to establish a secure connection with the server.
    | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
@@ -161,6 +162,7 @@
            port
            remote-address
            local-address
+           unix-socket
            ssl-context
            ssl?
            insecure?
@@ -190,7 +192,7 @@
         local-address
         epoll?
         nil
-        nil
+        unix-socket
         kqueue?)
       (d/catch' #(d/error! s %)))
     s))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -192,10 +192,15 @@
               (netty/insecure-ssl-client-context)
               (netty/ssl-client-context))))
         bootstrap-transform
-        (or remote-address (InetSocketAddress. ^String host (int port)))
+        (netty/coerce-socket-address {:scoket-address remote-address
+                                      :unix-socket unix-socket
+                                      :host host
+                                      :port port})
         local-address
         epoll?
         nil
+        ;; hack so we can define both host/port and unix domain socket
+        ;; to setup SSL handler properly
         (when (some? unix-socket)
           (if (instance? DomainSocketAddress unix-socket)
             unix-socket

--- a/src/aleph/udp.clj
+++ b/src/aleph/udp.clj
@@ -53,7 +53,6 @@
          bootstrap-transform identity}}]
   (let [in (atom nil)
         d (d/deferred)
-        epoll? 
 
         [g ^Class channel]
         (cond

--- a/src/aleph/udp.clj
+++ b/src/aleph/udp.clj
@@ -18,7 +18,9 @@
     [io.netty.channel.socket.nio
      NioDatagramChannel]
     [io.netty.channel.epoll
-     EpollDatagramChannel]))
+     EpollDatagramChannel]
+    [io.netty.channel.kqueue
+     KQueueDatagramChannel]))
 
 (p/def-derived-map UdpPacket [^DatagramPacket packet content]
   :sender (-> packet ^InetSocketAddress (.sender))
@@ -33,22 +35,40 @@
    | `port` | the port at which UDP packets can be received.  If both this and `:socket-address` are undefined, packets can only be sent.
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
    | `broadcast?` | if true, all UDP datagrams are broadcast.
+   | `epoll?` | if `true`, uses `epoll` transport when available, defaults to `false`.
+   | `kqueue?` | if `true`, uses `KQueue` transport when available, defaults to `false`.
    | `bootstrap-transform` | a function which takes the Netty `Bootstrap` object, and makes any desired changes before it's bound to a socket.
    | `raw-stream?` | if true, the `:message` within each packet will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users."
-  [{:keys [socket-address port broadcast? raw-stream? bootstrap-transform epoll?]
+  [{:keys [socket-address
+           port
+           broadcast?
+           raw-stream?
+           bootstrap-transform
+           epoll?
+           kqueue?]
     :or {epoll? false
+         kqueue? false
          broadcast? false
          raw-stream? false
          bootstrap-transform identity}}]
   (let [in (atom nil)
         d (d/deferred)
-        epoll? (and epoll? (netty/epoll-available?))
-        g (if epoll?
-            @netty/epoll-client-group
-            @netty/nio-client-group)
+        epoll? 
+
+        [g ^Class channel]
+        (cond
+          (and epoll? (netty/epoll-available?))
+          [@netty/epoll-client-group EpollDatagramChannel]
+
+          (and kqueue? (netty/kqueue-available?))
+          [@netty/kqueue-client-group KQueueDatagramChannel]
+
+          :else
+          [@netty/nio-client-group NioDatagramChannel])
+
         b (doto (Bootstrap.)
             (.group g)
-            (.channel (if epoll? EpollDatagramChannel NioDatagramChannel))
+            (.channel channel)
             (.option ChannelOption/SO_BROADCAST (boolean broadcast?))
             (.handler
               (netty/channel-inbound-handler

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -213,23 +213,25 @@
            (:body
             @(http-get (str "http://localhost:" port "/" path)))))))))
 
-(deftest test-response-formats-with-native-transports
-  (with-native-transport basic-handler
-    (doseq [[index [path result]] (map-indexed vector expected-results)]
-      (is
-       (= result
-          (bs/to-string
-           (:body
-            @(http-get (str "http://localhost:" port "/" path)))))))))
+(when (netty/native-transport-available?)
+  (deftest test-response-formats-with-native-transports
+    (with-native-transport basic-handler
+      (doseq [[index [path result]] (map-indexed vector expected-results)]
+        (is
+         (= result
+            (bs/to-string
+             (:body
+              @(http-get (str "http://localhost:" port "/" path))))))))))
 
-(deftest test-response-formats-with-unix-domain
-  (with-unix-domain basic-handler
-    (doseq [[index [path result]] (map-indexed vector expected-results)]
-      (is
-       (= result
-          (bs/to-string
-           (:body
-            @(http-get (str "http://localhost/" path)))))))))
+(when (netty/native-transport-available?)
+  (deftest test-response-formats-with-unix-domain
+    (with-unix-domain basic-handler
+      (doseq [[index [path result]] (map-indexed vector expected-results)]
+        (is
+         (= result
+            (bs/to-string
+             (:body
+              @(http-get (str "http://localhost/" path))))))))))
 
 (deftest test-compressed-response
   (with-compressed-handler basic-handler

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -213,19 +213,6 @@
                                                :kqueue? true})
        ~@body)))
 
-(defmacro with-unix-domain-socket [handler & body]
-  `(let [path# "/tmp/aleph-http.sock"]
-     (testing "path to socket"
-       (binding [*connection-options* {:unix-socket path#}]
-         (with-server (http/start-server ~handler {:unix-socket path#})
-           ~@body)))
-
-     (testing "file descriptor"
-       (let [fd# (io/file path#)]
-         (binding [*connection-options* {:unix-socket fd#}]
-           (with-server (http/start-server ~handler {:unix-socket fd#})
-             ~@body))))))
-
 ;;;
 
 (deftest test-response-formats
@@ -246,16 +233,6 @@
             (bs/to-string
              (:body
               @(http-get (str "http://localhost:" port "/" path))))))))))
-
-(when (netty/native-transport-available?)
-  (deftest test-response-formats-with-unix-domain-socket
-    (with-unix-domain-socket basic-handler
-      (doseq [[index [path result]] (map-indexed vector expected-results)]
-        (is
-         (= result
-            (bs/to-string
-             (:body
-              @(http-get (str "http://localhost/" path))))))))))
 
 (deftest test-compressed-response
   (with-compressed-handler basic-handler

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -39,19 +39,3 @@
                             :kqueue? true})]
         (s/put! c "foo")
         (is (= "foo" (bs/to-string @(s/take! c))))))))
-
-(when (netty/native-transport-available?)
-  (deftest test-echo-with-unix-socket
-    (let [path "/tmp/aleph.sock"]
-      (testing "path to socket file"
-        (with-server (tcp/start-server echo-handler {:unix-socket path})
-          (let [c @(tcp/client {:unix-socket path})]
-            (s/put! c "foo")
-            (is (= "foo" (bs/to-string @(s/take! c)))))))
-
-      (testing "file descriptor"
-        (let [fd (io/file path)]
-          (with-server (tcp/start-server echo-handler {:unix-socket fd})
-            (let [c @(tcp/client {:unix-socket fd})]
-              (s/put! c "foo")
-              (is (= "foo" (bs/to-string @(s/take! c)))))))))))

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -24,3 +24,14 @@
     (let [c @(tcp/client {:host "localhost", :port 10001})]
       (s/put! c "foo")
       (is (= "foo" (bs/to-string @(s/take! c)))))))
+
+(deftest test-echo-with-native-transport
+  (with-server (tcp/start-server echo-handler {:port 10001
+                                               :epoll? true
+                                               :kqueue? true})
+    (let [c @(tcp/client {:host "localhost"
+                          :port 10001
+                          :epoll? true
+                          :kqueue? true})]
+      (s/put! c "foo")
+      (is (= "foo" (bs/to-string @(s/take! c)))))))

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -25,19 +25,20 @@
       (s/put! c "foo")
       (is (= "foo" (bs/to-string @(s/take! c)))))))
 
-(deftest test-echo-with-native-transport
-  (with-server (tcp/start-server echo-handler {:port 10001
-                                               :epoll? true
-                                               :kqueue? true})
-    (let [c @(tcp/client {:host "localhost"
-                          :port 10001
-                          :epoll? true
-                          :kqueue? true})]
-      (s/put! c "foo")
-      (is (= "foo" (bs/to-string @(s/take! c)))))))
+(when (netty/native-transport-available?)
+  (deftest test-echo-with-native-transport
+    (with-server (tcp/start-server echo-handler {:port 10001
+                                                 :epoll? true
+                                                 :kqueue? true})
+      (let [c @(tcp/client {:host "localhost"
+                            :port 10001
+                            :epoll? true
+                            :kqueue? true})]
+        (s/put! c "foo")
+        (is (= "foo" (bs/to-string @(s/take! c))))))))
 
-(deftest test-echo-with-unix-socket
-  (when (netty/native-transport-available?)
+(when (netty/native-transport-available?)
+  (deftest test-echo-with-unix-socket
     (with-server (tcp/start-server echo-handler {:unix-socket "/tmp/aleph.sock"})
       (let [c @(tcp/client {:unix-socket "/tmp/aleph.sock"})]
         (s/put! c "foo")

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -35,3 +35,10 @@
                           :kqueue? true})]
       (s/put! c "foo")
       (is (= "foo" (bs/to-string @(s/take! c)))))))
+
+(deftest test-echo-with-unix-socket
+  (when (netty/native-transport-available?)
+    (with-server (tcp/start-server echo-handler {:unix-socket "/tmp/aleph.sock"})
+      (let [c @(tcp/client {:unix-socket "/tmp/aleph.sock"})]
+        (s/put! c "foo")
+        (is (= "foo" (bs/to-string @(s/take! c))))))))

--- a/test/aleph/udp_test.clj
+++ b/test/aleph/udp_test.clj
@@ -17,7 +17,9 @@
 (def words (slurp "/usr/share/dict/words"))
 
 (deftest test-echo
-  (let [s @(udp/socket {:port 10001, :epoll? true})]
+  (let [s @(udp/socket {:port 10001
+                        :epoll? true
+                        :kqueue? true})]
     (s/put! s {:host "localhost", :port 10001, :message "foo"})
     (is (= "foo"
           (bs/to-string

--- a/test/aleph/udp_test.clj
+++ b/test/aleph/udp_test.clj
@@ -17,12 +17,21 @@
 (def words (slurp "/usr/share/dict/words"))
 
 (deftest test-echo
+  (let [s @(udp/socket {:port 10001})]
+    (s/put! s {:host "localhost", :port 10001, :message "foo"})
+    (is (= "foo"
+           (bs/to-string
+            (:message
+             @(s/take! s)))))
+    (s/close! s)))
+
+(deftest test-echo-with-native-transport
   (let [s @(udp/socket {:port 10001
                         :epoll? true
                         :kqueue? true})]
     (s/put! s {:host "localhost", :port 10001, :message "foo"})
     (is (= "foo"
-          (bs/to-string
+           (bs/to-string
             (:message
-              @(s/take! s)))))
+             @(s/take! s)))))
     (s/close! s)))

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -85,15 +85,15 @@
   (with-compressing-handler echo-handler
     (let [c @(http/websocket-client "ws://localhost:8080" {:compression? true})]
       (is @(s/put! c "hello compressed"))
-      (is (= "hello compressed" @(s/try-take! c 5e3)))))
+      (is (= "hello compressed" @(s/try-take! c 5e3))))))
 
-  (when (netty/native-transport-available?)
-    (testing "webscoket server with native transport"
-      (with-native-transport
-        (let [c @(http/websocket-client "ws://localhost:8080"
-                                        {:epoll? true :kqueue? true})]
-          (is @(s/put! c "hello with native transport"))
-          (is (= "hello with native transport" @(s/try-take! c 5e3))))))))
+(when (netty/native-transport-available?)
+  (deftest test-websocket-with-native-transport
+    (with-native-transport
+      (let [c @(http/websocket-client "ws://localhost:8080"
+                                      {:epoll? true :kqueue? true})]
+        (is @(s/put! c "hello with native transport"))
+        (is (= "hello with native transport" @(s/try-take! c 5e3)))))))
 
 (deftest test-ping-pong-protocol
   (testing "empty ping from the client"

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -89,7 +89,7 @@
 
 (when (netty/native-transport-available?)
   (deftest test-websocket-with-native-transport
-    (with-native-transport
+    (with-native-transport echo-handler
       (let [c @(http/websocket-client "ws://localhost:8080"
                                       {:epoll? true :kqueue? true})]
         (is @(s/put! c "hello with native transport"))


### PR DESCRIPTION
> Quick note. Marked  as WIP. Relies on #477 to be merged beforehand, so I can implement proper support for KQueue settings for DNS resolvers.

There're still a few things I want to discuss.

## KQueue

Overall it works the same way `:epoll?` works for TCP, HTTP, WebSockets, UDP and DNS by specifying `:kqueue?` option. `false` by default, to be consistent with `epoll?`. At first glance it feels a bit weird to carry two arguments `epoll?` and `kqueue?` here and there, but on the hand that gives me the ability to switch ON both native transports whenever possible (both will not be available on the same host).

`io.netty/netty-transport-native-epoll` dependency should also be specified with appropriate classifier ("osx-x86_64"). This is the same problem we have in #475. With the recent commits, I updated `project.clj` to include classifiers right away, both for epoll and kqueue JARs. Generally, this should work, apart from the fact, your JAR would be 180kb larger. It also may lead to some problems with transitive dependencies from other libraries, but I don't have a lot of experience with classpath resolution order when using classifiers. So, let's discuss it. The obvious advantage here: less confusion for users when working with native transports.

Netty `4.1.33.Final` has a weird [issue](https://github.com/netty/netty/issues/8849) with KQueue selector which I'm still struggling to catch. Hope the next version of Netty will fix this, so we can ship w/o concerns. Updated: [seems to be fixed](https://github.com/netty/netty/pull/8881) already.

## Unix Domain Socket

Unix domain socket support added for TCP & HTTP both for client and server. Unix socket works only with native transports (epoll or kqueue), Netty does not support it with NIO (yet?).

TCP API

```clojure
user=> (def s1 (tcp/start-server (fn [s _] (s/connect s s)) {:unix-socket "/tmp/tcp-server.sock"}))
#'user/s1
user=> (def c1 @(tcp/client {:unix-socket "/tmp/tcp-server.sock"}))
#'user/c1
user=> (s/put! c1 "hello")
<< … >>
user=> @(s/take! c1)
#object["[B" 0x2eb44ff0 "[B@2eb44ff0"]
user=> (.close s1)
nil
```

HTTP API

```clojure
user=> (require '[aleph.http :as http])
nil
user=> (def s1 (http/start-server (fn [_] {:status 200 :body "OK"}) {:unix-socket "/tmp/server1.sock"}))
#'user/s1
user=> (def p (http/connection-pool {:connection-options {:unix-socket "/tmp/server1.sock"}}))
#'user/p
user=> (-> (http/get "http://domain/info" {:pool p}) deref :status)
200
```

There are a few points to mention here. When connecting to unix domain socket, we still require a valid parsable URL (host + scheme). We still need hostname to acquire a connection from the pool, setup SSL handler (improved, not trying to set SNI hostname if no `InetSocketAddress` available) and render "Host" header (this might be required by the server). `curl` has the same problem, so I think that's a reasonable trade-off. Quite a few tools use `http+unix://<socket-file>/<path>` to convey both unix socket filepath and "fake" domain, if that's interesting for users we can always implement this on top of the existing functionality.

From an implementation point of view, there're still some rough edges I'm not sure about. Notably, `netty/create-client` accepts `remote-address` option in the form of `InetSocketAddress`, we can relax that to `SocketAddress` and pass `DomainSocketAddress` right away... but that doesn't work in case we need to pass both inet (with host, port) and domain address (to connect to). `create-client` now takes both params, dynamically choose what address to connect to and rejects SSL handler setup if no `InetSocketAddress` provided (throwing exception in case `ssl-context` given with no host/port information). Overall, the number of positional arguments for `netty/create-client` looks awful right now, I'll probably reimplement that to accept a map of params (done).

Proxy options are rejected when connecting to unix domain socket, DNS resolver is set to `:noop` to bypass any attempts to resolve host before sending the request (we do just the same when sending requests through proxies).

@ztellman Waiting for your review! 