### PR TITLE
Reimplement http client timeouts using hashed wheel timer

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -88,7 +88,7 @@
 (def default-response-executor
   (flow/utilization-executor 0.9 256 {:onto? false}))
 
-(def default-timer
+(defonce default-timer
   (delay (netty/create-timer)))
 
 (defn connection-pool


### PR DESCRIPTION
The motivation behind it was described [here](https://github.com/ztellman/aleph/issues/479).

`http/request` now uses the default shared timer or provided as a parameter. On higher loads it makes sense to use different timeouts instead of a single instance even tho' hashed wheel timer is designed to handle thousands of simultaneous tasks with almost no visible performance degradation. It would be probably nicer to have `timer` being attached to a specific connections pool, but the current implementation does not let us attach arbitrary artifacts to `flow/instrumented-pool`... any other approaches would either break compatibility or would look weird. 

@alexander-yakushev Please, take a look when you have time. Thanks!