### PR TITLE
Introduce activity logger configuration for the server

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -49,7 +49,8 @@
    | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
-   | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds"
+   | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds.
+   | `log-activity` | when set, logs all events on each channel (connection) with a log level given. Accepts either one of `:trace`, `:debug`, `:info`, `:warn`, `:error` or an instance of `io.netty.handler.logging.LogLevel`. Note, that this setting *does not* enforce any changes to the logging configuration (default configuration is `INFO`, so you won't see any `DEBUG` or `TRACE` level messages, unless configured explicitly)."
   [handler options]
   (server/start-server handler options))
 


### PR DESCRIPTION
API looks the same way it looks for clients. `:log-activity` param includes `LoggingHandler` as a top-level handler.

To track operations on each child channels we still need to use `pipeline-transform`, I'm still not sure how to distinguish the two: maybe `:child-log-activity`? "Child" might be confusing as this term from Netty was never exposed before. `:handler-log-activity?`... even more confusing. As a simple workaround, we can set the same logger both for server and handlers. Less flexibility but that's probably what you need when debugging. @ztellman WDYT?

```clojure
user=> (def s (http/start-server (fn [_] {:status 200}) {:port 2020 :log-activity :warn}))
#'user/s
[aleph-netty-server-event-pool-1] WARN aleph-server - [id: 0xe168e395] REGISTERED
[aleph-netty-server-event-pool-1] WARN aleph-server - [id: 0xe168e395] BIND: 0.0.0.0/0.0.0.0:2020
[aleph-netty-server-event-pool-1] WARN aleph-server - [id: 0xe168e395, L:/0:0:0:0:0:0:0:0:2020] ACTIVE
[aleph-netty-server-event-pool-1] WARN aleph-server - [id: 0xe168e395, L:/0:0:0:0:0:0:0:0:2020] READ: [id: 0x0c71398b, L:/0:0:0:0:0:0:0:1:2020 - R:/0:0:0:0:0:0:0:1:54059]
[aleph-netty-server-event-pool-1] WARN aleph-server - [id: 0xe168e395, L:/0:0:0:0:0:0:0:0:2020] READ COMPLETE
```

P.S. This PR obviously conflicts with a few previous changes, e.g. Kqueue. Publishing this earlier not to lose once again :) 