### PR TITLE
Handle 308 Permanent Redirect (same behaviour than for 307)

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -201,7 +201,7 @@
 
 ;; Statuses for which clj-http will not throw an exception
 (def unexceptional-status?
-  #{200 201 202 203 204 205 206 207 300 301 302 303 304 307})
+  #{200 201 202 203 204 205 206 207 300 301 302 303 304 307 308})
 
 ;; helper methods to determine realm of a response
 (defn success?
@@ -343,7 +343,7 @@
         :else
         rsp-r)
 
-      (= 307 status)
+      (#{307 308} status)
       (if (or (#{:get :head} request-method)
             (opt req :force-redirects))
         (follow-redirect client


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308:

> The HyperText Transfer Protocol (HTTP) 308 Permanent Redirect redirect status response code indicates that the resource requested has been definitively moved to the URL given by the Location headers. A browser redirects to this page and search engines update their links to the resource (in 'SEO-speak', it is said that the 'link-juice' is sent to the new URL).

> The request method and the body will not be altered, whereas 301 may incorrectly sometimes be changed to a GET method.