### PR TITLE
Improve raw-stream example

### DIFF
--- a/examples/src/aleph/examples/http.clj
+++ b/examples/src/aleph/examples/http.clj
@@ -174,12 +174,12 @@
 ;; that our consumption of the body needs to be synchronous, as shown above by coercing it
 ;; to a Clojure seq.  If we want to have the body be asynchronous, we need to specify
 ;; `:raw-stream?` to be `true` for request connection pool.
-(def connection-pool (http/connection-pool {:connection-options {:raw-stream? true}})
+(def raw-stream-connection-pool (http/connection-pool {:connection-options {:raw-stream? true}})
 
 @(d/chain
    (http/get "http://localhost:10000/numbers"
      {:query-params {:count 10}
-      :pool connection-pool})
+      :pool raw-stream-connection-pool})
    :body
    #(s/map bs/to-byte-array %)
    #(s/reduce conj [] %)
@@ -215,7 +215,7 @@
       (.keyManager (file cert) (file key))
       .build))
 
-(defn ssl-connection-pool
+(defn build-ssl-connection-pool
   "To use the SSL context, we set the `:ssl-context` connection option on a connection pool. This
   allows the pool to make TLS connections with our client certificate."
   [ca cert key]
@@ -223,12 +223,14 @@
    {:connection-options
     {:ssl-context (build-ssl-context ca cert key)}}))
 
+(def ssl-connection-pool
+  (build-ssl-connection-pool "path/to/ca.crt" "path/to/cert.crt" "path/to/key.k8"))
+
 ;; We can use our `ssl-connection-pool` builder to GET pages from our target endpoint by passing the
 ;; `:pool` option to `aleph.http/get`.
-
 @(d/chain
   (http/get
    "https://server.with.tls.client.auth"
-   {:pool (ssl-connection-pool "path/to/ca.crt" "path/to/cert.crt" "path/to/key.k8")})
+   {:pool ssl-connection-pool})
   :body
   bs/to-string)

--- a/examples/src/aleph/examples/http.clj
+++ b/examples/src/aleph/examples/http.clj
@@ -174,10 +174,12 @@
 ;; that our consumption of the body needs to be synchronous, as shown above by coercing it
 ;; to a Clojure seq.  If we want to have the body be asynchronous, we need to specify
 ;; `:raw-stream?` to be `true` for request connection pool.
+(def connection-pool (http/connection-pool {:connection-options {:raw-stream? true}})
+
 @(d/chain
    (http/get "http://localhost:10000/numbers"
      {:query-params {:count 10}
-      :pool (http/connection-pool {:connection-options {:raw-stream? true}})})
+      :pool connection-pool})
    :body
    #(s/map bs/to-byte-array %)
    #(s/reduce conj [] %)


### PR DESCRIPTION
Minor tweak to `:raw-stream?` example to prevent future readers from following the example directly and ending up with a program that creates a connection-pool on every request (...eventually consuming all threads on the OS).