### PR TITLE
Support -Dio.netty.eventLoopThreads for start-server

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -53,7 +53,8 @@
    | `log-activity` | when set, logs all events on each channel (connection) with a log level given. Accepts either one of `:trace`, `:debug`, `:info`, `:warn`, `:error` or an instance of `io.netty.handler.logging.LogLevel`. Note, that this setting *does not* enforce any changes to the logging configuration (default configuration is `INFO`, so you won't see any `DEBUG` or `TRACE` level messages, unless configured explicitly).
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
    | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring responseo to be used as a reject response or deferred that yields one of those.
-   | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread."
+   | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
+   | `num-event-loop-threads` | optional, defaults to double number of available processors."
   [handler options]
   (when (contains? options :max-chunk-size)
     (log/warn "Ignoring :max-chunk-size option as it was deprecated"))

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -994,7 +994,7 @@
    on-close
    ^SocketAddress socket-address
    epoll?]
-  (let [num-threads    (get-default-event-loop-threads)
+  (let [num-threads    (long (get-default-event-loop-threads))
         thread-factory (enumerating-thread-factory "aleph-netty-server-event-pool" false)
         closed?        (atom false)
 

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1197,31 +1197,19 @@
            "port, or socket-address should be specified")))))
 
 (defn start-server
-  ([pipeline-builder
-    ssl-context
-    bootstrap-transform
-    on-close
-    ^SocketAddress socket-address
-    epoll?]
-   (start-server pipeline-builder
-                 ssl-context
-                 bootstrap-transform
-                 on-close
-                 socket-address
-                 epoll?
-                 false
-                 nil))
-  ([pipeline-builder
-    ssl-context
-    bootstrap-transform
-    on-close
-    ^SocketAddress socket-address
-    epoll?
-    kqueue?
-    logger]
-   (let [num-threads    (long (get-default-event-loop-threads))
+  ([{:keys [pipeline-builder
+            ssl-context
+            bootstrap-transform
+            on-close
+            ^SocketAddress socket-address
+            epoll?
+            kqueue?
+            logger
+            num-event-loop-threads]}]
+   (let [num-threads (long (or num-event-loop-threads
+                               (get-default-event-loop-threads)))
          thread-factory (enumerating-thread-factory "aleph-netty-server-event-pool" false)
-         closed?        (atom false)
+         closed? (atom false)
 
          [^Class channel ^EventLoopGroup group]
          (cond
@@ -1293,4 +1281,34 @@
 
        (catch Exception e
          @(.shutdownGracefully group)
-         (throw e))))))
+         (throw e)))))
+  ([pipeline-builder
+    ssl-context
+    bootstrap-transform
+    on-close
+    ^SocketAddress socket-address
+    epoll?]
+   (start-server {:pipeline-builder pipeline-builder
+                  :ssl-context ssl-context
+                  :bootstrap-transform bootstrap-transform
+                  :on-close on-close
+                  :socket-address socket-address
+                  :epoll? epoll?
+                  :kqueue? false
+                  :logger nil}))
+  ([pipeline-builder
+    ssl-context
+    bootstrap-transform
+    on-close
+    ^SocketAddress socket-address
+    epoll?
+    kqueue?
+    logger]
+   (start-server {:pipeline-builder pipeline-builder
+                  :ssl-context ssl-context
+                  :bootstrap-transform bootstrap-transform
+                  :on-close on-close
+                  :socket-address socket-address
+                  :epoll? epoll?
+                  :kqueue? kqueue?
+                  :logger logger})))

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -994,8 +994,7 @@
    on-close
    ^SocketAddress socket-address
    epoll?]
-  (let [num-cores      (.availableProcessors (Runtime/getRuntime))
-        num-threads    (* 2 num-cores)
+  (let [num-threads    (get-default-event-loop-threads)
         thread-factory (enumerating-thread-factory "aleph-netty-server-event-pool" false)
         closed?        (atom false)
 


### PR DESCRIPTION
Uses `get-default-event-loop-threads` which is the same logic as the clients.