### PR TITLE
Improved SSL handlers

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -36,7 +36,7 @@
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` |  a `java.net.SocketAddress` specifying both the port and interface to bind to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
-   | `ssl-context` | an `io.netty.handler.ssl.SslContext` object if an SSL connection is desired |
+   | `ssl-context` | an `io.netty.handler.ssl.SslContext` object or a map of SSL context options (see `aleph.netty/ssl-server-context` for more details) if an SSL connection is desired |
    | `manual-ssl?` | set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform`) to select the SSL context based on the client's indicated host name. |
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `executor` | a `java.util.concurrent.Executor` which is used to handle individual requests.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
@@ -112,7 +112,7 @@
    the `connection-options` are a map describing behavior across all connections:
 
    |:---|:---
-   | `ssl-context` | an `io.netty.handler.ssl.SslContext` object, only required if a custom context is required
+   | `ssl-context` | an `io.netty.handler.ssl.SslContext` object or a map of SSL context options (see `aleph.netty/ssl-client-context` for more details), only required if a custom context is required
    | `local-address` | an optional `java.net.SocketAddress` describing which local interface should be used
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.Bootstrap` object and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -103,6 +103,21 @@
           nil))
       (no-url req))))
 
+(defn exception-handler [ctx ex response-stream]
+  (cond
+    ;; could happens when io.netty.handler.codec.http.HttpObjectAggregator
+    ;; is part of the pipeline
+    (instance? TooLongFrameException ex)
+    (s/put! response-stream ex)
+
+    ;; when SSL handshake failed
+    (http/ssl-handshake-error? ex)
+    (let [^Throwable handshake-error (.getCause ^Throwable ex)]
+      (s/put! response-stream handshake-error))
+
+    (not (instance? IOException ex))
+    (log/warn ex "error in HTTP client")))
+
 (defn raw-client-handler
   [response-stream buffer-capacity]
   (let [stream (atom nil)
@@ -120,8 +135,7 @@
 
       :exception-caught
       ([_ ctx ex]
-        (when-not (instance? IOException ex)
-          (log/warn ex "error in HTTP client")))
+        (exception-handler ctx ex response-stream))
 
       :channel-inactive
       ([_ ctx]
@@ -172,14 +186,7 @@
 
       :exception-caught
       ([_ ctx ex]
-        (cond
-          ; could happens when io.netty.handler.codec.http.HttpObjectAggregator
-          ; is part of the pipeline
-          (instance? TooLongFrameException ex)
-          (s/put! response-stream ex)
-
-          (not (instance? IOException ex))
-          (log/warn ex "error in HTTP client")))
+        (exception-handler ctx ex response-stream))
 
       :channel-inactive
       ([_ ctx]

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -23,6 +23,7 @@
      ByteBuf]
     [java.nio
      ByteBuffer]
+    [io.netty.handler.codec DecoderException]
     [io.netty.handler.codec.http
      DefaultHttpRequest DefaultLastHttpContent
      DefaultHttpResponse DefaultFullHttpRequest
@@ -61,7 +62,8 @@
      ConcurrentLinkedQueue
      TimeUnit]
     [java.util.concurrent.atomic
-     AtomicBoolean]))
+     AtomicBoolean]
+    [javax.net.ssl SSLHandshakeException]))
 
 (def non-standard-keys
   (let [ks ["Content-MD5"
@@ -672,3 +674,7 @@
              (when (and (identical? ::ping-timeout v)
                         (.isOpen ^Channel (.channel ctx)))
                (netty/close ctx))))))))
+
+(defn ssl-handshake-error? [^Throwable ex]
+  (and (instance? DecoderException ex)
+       (instance? SSLHandshakeException (.getCause ex))))

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -210,7 +210,13 @@
                       (invalid-value-response req rsp))))))))))))
 
 (defn exception-handler [ctx ex]
-  (when-not (instance? IOException ex)
+  (cond
+    ;; do not need to log an entire stack trace when SSL handshake failed
+    (http/ssl-handshake-error? ex)
+    (log/warn "SSL handshake failure:"
+              (.getMessage ^Throwable (.getCause ^Throwable ex)))
+
+    (not (instance? IOException ex))
     (log/warn ex "error in HTTP server")))
 
 (defn invalid-request? [^HttpRequest req]


### PR DESCRIPTION
PR to replace #487, includes

* SSL context might be passed a Clojure map (in addition to `SslContext` object support)
* suppress full stacktrace for SSL handshake error