### PR TITLE
Avoid NullPointerException if optional timeout omitted.

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -661,7 +661,7 @@
                                                                 timeout]}]
   (let [done (d/deferred)]
     (websocket-ping conn done payload)
-    (when (pos? timeout)
+    (when (and timeout (pos? timeout))
       (-> done
           (d/timeout! timeout ::ping-timeout)
           (d/chain'


### PR DESCRIPTION
pos? throws an exception for a nil value, and yet timeout is documented as being optional.